### PR TITLE
Modify references to User to allow for custom User model

### DIFF
--- a/src/automations/flow.py
+++ b/src/automations/flow.py
@@ -7,13 +7,16 @@ import threading
 import traceback
 from copy import copy
 
-from django.contrib.auth.models import User, Group, Permission
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, MultipleObjectsReturned
 from django.db.models import Model, Q
 from django.db.transaction import atomic
 from django.utils.timezone import now
 
 from . import models, settings
+
+User = get_user_model()
 
 """To allow forward references in Automation object "this" is defined"""
 

--- a/src/automations/models.py
+++ b/src/automations/models.py
@@ -4,7 +4,7 @@ import sys
 import datetime
 from logging import getLogger
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
@@ -16,6 +16,8 @@ from . import settings
 # Create your models here.
 
 logger = getLogger(__name__)
+
+User = get_user_model()
 
 
 def get_automation_class(dotted_name):
@@ -126,7 +128,7 @@ class AutomationTaskModel(models.Model):
         verbose_name=_("Requires interaction")
     )
     interaction_user = models.ForeignKey(
-            'auth.User',
+            settings.AUTH_USER_MODEL,
             null=True,
             on_delete=models.PROTECT,
             verbose_name=_("Assigned user"),

--- a/src/automations/settings.py
+++ b/src/automations/settings.py
@@ -15,3 +15,5 @@ TASK_LIST_TEMPLATES = getattr(settings, 'ATM_TASK_LIST_TEMPLATES',
                               (
                                   ('automations/includes/task_list.html', _("Default template")),
                               ))
+
+AUTH_USER_MODEL = getattr(settings, "AUTH_USER_MODEL", "auth.User")

--- a/src/automations/tests.py
+++ b/src/automations/tests.py
@@ -3,7 +3,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from django import forms
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management import execute_from_command_line
 from django.test import TestCase
 import datetime
@@ -19,6 +19,8 @@ from django.test import RequestFactory
 
 
 # Create your tests here.
+
+User = get_user_model()
 
 
 class Print(flow.Execute):


### PR DESCRIPTION
Code currently references the `auth.User` model, but many (most) projects use a custom User model set in `settings.AUTH_USER_MODEL`, as [recommended in django docs](https://docs.djangoproject.com/en/3.2/topics/auth/customizing/#using-a-custom-user-model-when-starting-a-project). The current code results in errors for any project with custom User installing django-automations.

- Modified reference to `auth.User` in models.py to refer to settings.AUTH_USER_MODEL. Because django-automations uses an app-level settings file, this required importing that setting from the project-level settings.py into the app-level settings.py, and then importing to models.py
- For other references to the User model, updated code to use Django's `get_user_model()`

Referenced in #3 