### PR TITLE
Delete history command

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -771,6 +771,13 @@ Management command
 This wrapper calls the class method ``models.AutomationModel.run()`` which in turn lets all automations run which are not waiting for a response (filled form, other condition) or a certain point in time.
 
 
+.. code-block:: bash
+
+    python manage.py automation_delete_history 14
+
+This wrapper calls the class method ``models.AutomationModel.delete_history()`` which in turn deletes all automations older than the specified number of days. Defaults to 30 days if no argument is provided.
+
+
 Settings in ``settings.py``
 ***************************
 

--- a/src/automations/management/commands/automation_delete_history.py
+++ b/src/automations/management/commands/automation_delete_history.py
@@ -1,0 +1,32 @@
+from logging import getLogger
+
+from django.core.management.base import BaseCommand
+
+from automations.models import AutomationModel
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Delete Automations older than the specified number of days (default=30)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "days_old",
+            type=int,
+            nargs="?",
+            help="The minumum age of an Automation (in days) before it is deleted",
+            default=30,
+        )
+
+    def handle(self, *args, **kwargs):
+        days_old = kwargs["days_old"]
+        total, info_dict = AutomationModel.delete_history(days_old)
+
+        automation_count = info_dict.get("automations.AutomationModel", 0)
+        task_count = info_dict.get("automations.AutomationTaskModel", 0)
+
+        self.stdout.write(
+            f"{total} total objects deleted, including {automation_count} AutomationModel "
+            f"instances, and {task_count} AutomationTaskModel instances"
+        )

--- a/src/automations/tests/test_automations.py
+++ b/src/automations/tests/test_automations.py
@@ -338,7 +338,7 @@ class RepeatTest(TestCase):
 
 
 class ManagementCommandTest(TestCase):
-    def test_managment_command(self):
+    def test_managment_step_command(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:
             atm = TestSplitJoin()
             execute_from_command_line(["manage.py", "automation_step"])
@@ -358,6 +358,19 @@ class ManagementCommandTest(TestCase):
         self.assertEqual(
             len(AutomationTaskModel.objects.filter(automation_id=db_id)), 0
         )
+
+    def test_managment_delete_command(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            atm = TestSplitJoin()
+            execute_from_command_line(["manage.py", "automation_delete_history 0"])
+        output = fake_out.getvalue().splitlines()
+        self.assertEqual(
+            output[0],
+            "4 total objects deleted, including 1 AutomationModel instances, and 3 "
+            "AutomationTaskModel instances"
+        )
+        self.assertEqual(AutomationModel.objects.count(), 0)
+        self.assertEqual(AutomationTaskModel.objects.count(), 0)
 
 
 class ExecutionErrorTest(TestCase):

--- a/src/automations/tests/test_automations.py
+++ b/src/automations/tests/test_automations.py
@@ -337,7 +337,7 @@ class RepeatTest(TestCase):
         self.assertIn("Allow to split and join", (name for _, name in tpl))
 
 
-class ManagementCommandTest(TestCase):
+class ManagementCommandStepTest(TestCase):
     def test_managment_step_command(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:
             atm = TestSplitJoin()
@@ -359,6 +359,8 @@ class ManagementCommandTest(TestCase):
             len(AutomationTaskModel.objects.filter(automation_id=db_id)), 0
         )
 
+
+class ManagementCommandDeleteTest(TestCase):
     def test_managment_delete_command(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:
             atm = TestSplitJoin()
@@ -371,6 +373,7 @@ class ManagementCommandTest(TestCase):
         )
         self.assertEqual(AutomationModel.objects.count(), 0)
         self.assertEqual(AutomationTaskModel.objects.count(), 0)
+        atm.kill()
 
 
 class ExecutionErrorTest(TestCase):

--- a/src/automations/tests/test_automations.py
+++ b/src/automations/tests/test_automations.py
@@ -362,7 +362,7 @@ class ManagementCommandTest(TestCase):
     def test_managment_delete_command(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:
             atm = TestSplitJoin()
-            execute_from_command_line(["manage.py", "automation_delete_history 0"])
+            execute_from_command_line(["manage.py", "automation_delete_history", "0"])
         output = fake_out.getvalue().splitlines()
         self.assertEqual(
             output[0],

--- a/src/automations/tests/test_automations.py
+++ b/src/automations/tests/test_automations.py
@@ -367,7 +367,7 @@ class ManagementCommandDeleteTest(TestCase):
             execute_from_command_line(["manage.py", "automation_delete_history", "0"])
         output = fake_out.getvalue().splitlines()
         self.assertIn(
-            "4 total objects deleted, including 1 AutomationModel instances, and 3 "
+            "12 total objects deleted, including 1 AutomationModel instances, and 11 "
             "AutomationTaskModel instances",
             output
         )

--- a/src/automations/tests/test_automations.py
+++ b/src/automations/tests/test_automations.py
@@ -366,10 +366,10 @@ class ManagementCommandDeleteTest(TestCase):
             atm = TestSplitJoin()
             execute_from_command_line(["manage.py", "automation_delete_history", "0"])
         output = fake_out.getvalue().splitlines()
-        self.assertEqual(
-            output[0],
+        self.assertIn(
             "4 total objects deleted, including 1 AutomationModel instances, and 3 "
-            "AutomationTaskModel instances"
+            "AutomationTaskModel instances",
+            output
         )
         self.assertEqual(AutomationModel.objects.count(), 0)
         self.assertEqual(AutomationTaskModel.objects.count(), 0)


### PR DESCRIPTION
Adds command for deleting automations that are older than the specified number of days, defaulting to 30 days.

- [x] Add command
- [x] Add documentation
- [x] Add tests

Resolves #12