### PR TITLE
Make small changes/corrections to docs

### DIFF
--- a/doc/core-concepts.rst
+++ b/doc/core-concepts.rst
@@ -9,7 +9,7 @@ Automations are nothing but well-defined processes designed to reach a goal. Whi
 * documentation of the automations is not complete or out of sync
 * multiple users or user groups are involved in one process and need to share information.
 
-Commonly, business processes are described using events, activities and gateways.
+Commonly, business processes are described using events, tasks, and gateways.
 
 Events
 ======
@@ -29,7 +29,7 @@ Work to be done by a user are represented by Django forms where the user has to 
 Gateways
 ========
 
-Gateways change the flow of an automation, e.g., depending on a condition. Django automation offers ``If()``, ``.Then()``, ``.Else()`` constructs. The ``Split()``/``Join()`` gateway allows to parallelize the automation.
+Gateways change the flow of an automation, e.g., depending on a condition. Django automations offers ``If()``, ``.Then()``, ``.Else()`` constructs. The ``Split()``/``Join()`` gateway allows to parallelize the automation.
 
 Example issue discussion cycle
 ******************************
@@ -40,7 +40,7 @@ issue list for discussion.
 .. image:: https://upload.wikimedia.org/wikipedia/commons/c/c0/BPMN-DiscussionCycle.jpg
     :alt: Business process Issue discussion cycle
 
-Django Automation allows to describe and document the process in one place, a python class (what else?).
+Django Automations allows to describe and document the process in one place, a python class (what else?).
 
 This process can be translated into an automation like this
 
@@ -57,10 +57,10 @@ This process can be translated into an automation like this
         repeat =        (flow.If(this.moderation_deadline_reached)
                             .Then(this.join)
                             .Else(this.moderation)
-                        ).AfterPausingFor(datetime.timedelta(hours=1))
+                        ).AfterWaitingFor(datetime.timedelta(hours=1))
 
         warning =       (flow.Execute(this.send_deadline_warning)
-                            .AfterPausingFor(datetime.timedelta(days=6))
+                            .AfterWaitingFor(datetime.timedelta(days=6))
                             .Next(this.join))
 
         conf_call =     flow.If(this.conf_call_this_week).Then(this.moderate_call).Else(this.join)
@@ -79,7 +79,7 @@ Automations have a state, i.e. they execute at one or more tasks. All execution 
 Let's say you wanted to automate the signup process for a webinar. Then a single session of a webinar with date and time might be the model instance you wanted to attach to the automation. This means each session of the webinar  would also have an independent automation instance managing the signup process including sending out the webinar link, reminding people when the webinar starts or offering a recording after the webinar. While during the process the session does not change the list of people who have signed up changes but still always refers to the same
 webinar session.
 
-Django automation has two optional ways of storing state data. The first one is **binding model instances to an automation instance** allowing for all form of data Django models can handle. Additionally each automation instance has **a json-serializable dictionary attached** called ``data``. Since it is stored in a Django ``JSONField`` it only may contain combination of basic types (like ``int``, ``real``, ``list``, ``dict``, ``None``). This data dictionary is also used to store results of form interactions or for automation methods to keep intermediate states to communicate with each other.
+Django automations has two optional ways of storing state data. The first one is **binding model instances to an automation instance** allowing for all form of data Django models can handle. Additionally each automation instance has **a json-serializable dictionary attached** called ``data``. Since it is stored in a Django ``JSONField`` it only may contain combination of basic types (like ``int``, ``real``, ``list``, ``dict``, ``None``). This data dictionary is also used to store results of form interactions or for automation methods to keep intermediate states to communicate with each other.
 
 Modifiers
 *********

--- a/doc/home.rst
+++ b/doc/home.rst
@@ -16,7 +16,7 @@ This setup leads to business logic being scattered around in a project: Bits
 and pieces of the same process appear in different views which in turn access
 several models and their logic.
 
-Django-automations aims to add another layer where business logic can be
+Django automations aims to add another layer where business logic can be
 maintained centrally. Just like models live in ``models.py``, views in ``views.py``
 automations are made to live in an app's ``automations.py``.
 
@@ -33,8 +33,8 @@ Implementation
 
 The implementation is done with a few objectives in mind:
 
-* **Lightweight:** Django-automations builds on proven Django elements: Models to keep the state of the processes and forms to manage user interaction. Ability to bind to other Django models, however, no need for migrations if bindings are changed or state information is added.
-* **Python syntax:** Just like models or forms are Python classes, automations are Python classes built in a similar way (from Nodes in stead of ModelFields or FormFields)
+* **Lightweight:** Django automations builds on proven Django elements: Models to keep the state of the processes and forms to manage user interaction. Ability to bind to other Django models, however, no need for migrations if bindings are changed or state information is added.
+* **Python syntax:** Just like models or forms are Python classes, automations are Python classes built in a similar way (from Nodes instead of ModelFields or FormFields)
 * **Easy extensibility:** To keep the core light, it is designed to allow for easy customization in a project.
 
 Benefits

--- a/doc/how-to.rst
+++ b/doc/how-to.rst
@@ -22,4 +22,4 @@ Hence, to remove a node from an automation with existing instances follow this p
 
 2. Run ``./manage.py automation_step``. This causes all automation instances with an open task at the node you want to delete to process the no-op and move to the next task.
 
-3. Remove the node. Removing is save now since an automation instance coming to the node immediately will execute to no-op and move to the next task.
+3. Remove the node. Removing is safe now since an automation instance coming to the node immediately will execute to no-op and move to the next task.

--- a/doc/introduction-to-automations.rst
+++ b/doc/introduction-to-automations.rst
@@ -20,7 +20,7 @@ Just like models live in ``models.py``, views in ``views.py``, forms in
 The basics:
 
 #. Automations are Python subclasses of ``flow.Automation``
-#. Each`attribute represents a task node, quite similar to Django models
+#. Each attribute represents a task node, quite similar to Django models
 #. All instances of automations are executed. Their states are kept in two models used by all Automations, quite in contrast to Django models where there is a one-to-one correspondence between model and table.
 
 Preparing your Django project
@@ -73,7 +73,7 @@ This automation executes four consecutive tasks before terminating. These tasks 
         send_reminder =     (flow.Execute(webinar.send_reminder_mail)
                                 .AfterWaitingUntil(webinar.reminder_time))
         send_replay_offer = (flow.Execute(webinar.send_replay_mail)
-                                .AfterPausingFor(datetime.timedelta(minutes=150)))
+                                .AfterWaitingFor(datetime.timedelta(minutes=150)))
         end =               flow.End()
 
         def init(self, task):
@@ -100,7 +100,7 @@ take parameters, like ``flow.Execute``, some do not, like ``flow.End()``.
 Node types
 ==========
 
-Django Automation has some built-in node types (see [reference](reference)).
+Django Automations has some built-in node types (see [reference](reference)).
 
 * ``flow.Execute()`` executes a Python callable, typically a method of the automation class to perform the task.
 * ``flow.End()`` terminates the execution of the current automation object.
@@ -134,7 +134,7 @@ Modifiers for all nodes (with the exception for ``flow.Form`` and
 * ``.Next(node)`` sets the node to continue with after finishing this node. If omitted the automation continues with the chronologically next node of the class. ``.Next`` resembles a goto statement. ``.Next`` takes a string or a ``This`` object as a parameter. A string denotes the name of the next node. The this object allows for a different syntax. ``.Next("next_node")`` and ``.Next(this.next_node)`` are equivalent.
 * ``.AsSoonAs(condition)`` waits for condition before continuing the automation. If condition is ``False`` the automation is interrupted and ``condition`` is checked the next time the automation instance is run.
 * ``.AfterWaitingUntil(datetime)`` stops the automation until the specific datetime has passed. Note that depending on how the scheduler runs the automation there might be a significant time slip between ``datetime`` and the real execution time. It is only guaranteed that the node is not executed before. ``datetime`` may be a callable.
-* ``.AfterPausingFor(timedelta)`` stops the automation for a specific amount of time. This is equivalent to ``.AfterWaitingUntil(lambda x: now()+timedelta)``.
+* ``.AfterWaitingFor(timedelta)`` stops the automation for a specific amount of time. This is equivalent to ``.AfterWaitingUntil(lambda x: now()+timedelta)``.
 * ``.SkipIf`` leaves a node unprocessed if a condition is fulfilled.
 
 Other nodes implement additional modifiers, e.g., ``.Then()`` and
@@ -151,7 +151,7 @@ node ``SendMail``:
 .. code-block:: python
 
     class SendMail(flow.Execute):
-        def method(self, task, mail_id):
+        def method(self, task_instance, mail_id):
             """here goes the code to be executed"""
 
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -334,7 +334,7 @@ work in progress
 flow.This and flow.this
 ***********************
 
-Nodes for an automation are specified as class attributes. To refer to other notds in the definition of a node, Django automations offers two options:
+Nodes for an automation are specified as class attributes. To refer to other nodes in the definition of a node, Django automations offers two options:
 
 1. Reference by string literal: ``.Next("next_node")`` will continue the automation with the node named ``next_node``
 2. Reference using the global ``This`` object instance ``this``: ``.Next(this.next_node)`` refers to the Automation objects ``next_node`` attribute. Since the classes' attributes are not accessible at definition time the this object buffers the reference. It is resolved when an instance is created and executed.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -46,10 +46,10 @@ Example:
         evaluate      = flow.Execute(this.evaluate)
         end           = flow.End()
 
-        def publish_announcement(self, task):
+        def publish_announcement(self, task_instance):
             ...
 
-        def no_new_mails(self, task):
+        def no_new_mails(self, task_instance):
             # Do something to check mails
             return not new_mail_found
 
@@ -248,7 +248,7 @@ Also, messages can be used create an instance of an automation and start it.
 Declaring receivers
 -------------------
 
-To receive messages automations have to declare receivers. Receivers are spacial methods of an automation class. Messages are always received by instances (and not the class itself).
+To receive messages automations have to declare receivers. Receivers are special methods of an automation class. Messages are always received by instances (and not the class itself).
 
 Receivers have names that begin with ``receive_`` followed by the message name. They take three parameters: ``self``, ``token``, and ``data``.
 
@@ -334,7 +334,7 @@ work in progress
 flow.This and flow.this
 ***********************
 
-Nodes for an automation are specified as class attributes. To refer to other notes in the definition of a node Django-automations offers two options:
+Nodes for an automation are specified as class attributes. To refer to other notds in the definition of a node, Django automations offers two options:
 
 1. Reference by string literal: ``.Next("next_node")`` will continue the automation with the node named ``next_node``
 2. Reference using the global ``This`` object instance ``this``: ``.Next(this.next_node)`` refers to the Automation objects ``next_node`` attribute. Since the classes' attributes are not accessible at definition time the this object buffers the reference. It is resolved when an instance is created and executed.
@@ -420,7 +420,7 @@ Attributes
 
     References a JsonField of the node's automation instance. Each instance of an automation can carry additional data in form of a JsonField. This data is shared by all nodes of the automation instance. The node's attribute returns the common JsonField. Any changes in the field need to be saved using ``.data.save()`` or they might be lost.
 
-    Attached model objects will be referenced by their id in the ``.data`` attribute. Beyond this the automation may use the data field to safe its   state in any way it prefers **as long as the dict is json serializable**. This excludes ``datetime`` objects or ``timedelta`` objects.
+    Attached model objects will be referenced by their id in the ``.data`` attribute. Beyond this the automation may use the data field to save its   state in any way it prefers **as long as the dict is json serializable**. This excludes ``datetime`` objects or ``timedelta`` objects.
 
 Additional methods
 ------------------
@@ -458,7 +458,7 @@ flow.Repeat
 
     allows for repetitive automations (which do not need an ``flow.End()`` node. The automation will resume at node given by the ``start`` argument, or - if omitted - from the first node.
 
-The repetition patter is described by **modifiers**:
+The repetition pattern is described by **modifiers**:
 
 .. py:method:: Repeat.EveryDayAt(hour, minute)
 
@@ -537,7 +537,7 @@ flow.SendMessage
 
 .. note::
 
-    The message is the same mechanism used by the template tags or CMS plugins to send a message when a specific page is rendered. If the message comes from the template tag or plugin ``date`` is the request object.
+    The message is the same mechanism used by the template tags or CMS plugins to send a message when a specific page is rendered. If the message comes from the template tag or plugin ``data`` is the request object.
 
 
 flow.Form
@@ -587,9 +587,13 @@ flow.get_automations
 
 .. py:function:: flow.get_automations(app=None)
 
-    returns either all automations in the current project (including those in dependencies if they are loaded). All modules or submodules named ``automations.py`` are searched. If the ``app`` parameter is given only ``app.automations`` is searched. Other submodules of ``app`` are ignored.
+    Returns all automations in the current project (including those in dependencies if they are loaded). All modules or submodules named ``automations.py`` are searched. If the ``app`` parameter is given only ``app.automations`` is searched. Other submodules of ``app`` are ignored.
 
 The result is a list of tuples, the first one being the automations dotted path, the second one its human readable name. It differs only from the path if ``verbose_name`` is set in the automations ``Meta`` subclass.
+
+    .. note::
+
+        Because of the way Python's ``sys`` checks for module modules names, automations (either the automation class or the automations.py file) must be imported somewhere within your project in order to be discoverable. Typically if you are using automations from within the project, it will already require imports, but if you are using an automation solely from the commandline, you can import its class in the ``AppConfig.ready()`` method within one of your project's apps.
 
 
 Models
@@ -613,11 +617,12 @@ All automation instances share a Django model class called ``models.AutomationMo
     ``models.AutomationModel.delete_history`` returns a tuple with two entries: The first is the number of deleted objects, the second
     a dictionary specifying how many automations and how many automation task objects have been deleted from the database.
 
+    This class method can be called through the management command ``./manage.py automation_delete_history``
+
     .. note::
 
         Regular deletion of the history keeps the database size from growing endlessly. It also might be required for
-        privacy reasons. Alternatives
-        include removing all person-related data from the automation.
+        privacy reasons. Alternatives include removing all person-related data from the automation.
 
     .. warning::
 
@@ -710,7 +715,7 @@ DashboardView
 Templates
 *********
 
-Django Automation comes with simplistic templates. They are largely thought to be a reference for implementing your project-specific set of templates which probably include some more markup to adapt to your project's look and feel.
+Django Automations comes with simplistic templates. They are largely thought to be a reference for implementing your project-specific set of templates which probably include some more markup to adapt to your project's look and feel.
 
 All template can be replaced simply by offering alternatives in your project's template folder. This is the structure:
 
@@ -760,7 +765,7 @@ This is the template used by the ``TaskListView``.
 Template tags
 *************
 
-Management command
+Management commands
 *******************
 
 
@@ -769,6 +774,13 @@ Management command
     python manage.py automation_step
 
 This wrapper calls the class method ``models.AutomationModel.run()`` which in turn lets all automations run which are not waiting for a response (filled form, other condition) or a certain point in time.
+
+
+.. code-block:: bash
+
+    python manage.py automation_delete_history 14
+
+This wrapper calls the class method ``models.AutomationModel.delete_history()`` which in turn deletes all automations older than the specified number of days. Defaults to 30 days if no argument is provided.
 
 
 Settings in ``settings.py``
@@ -798,7 +810,7 @@ Settings in ``settings.py``
 
     If your project uses non-standard permissions, specify a method for the AutomationTaskModel that will return a QuerySet of Users based on a the list of Permission codename strings, the User, and Group within the model instance itself. This setting should be a string of the dotted-path to the location of the replacement method. See :ref:`Non-standard Group and Permissions<Non-standard Group and Permissions>` for additional details.
 
-.. note::
+.. warning::
     Either all or none of the following must be present in your project's settings: ATM_GROUP_MODEL, ATM_USER_WITH_PERMISSIONS_FORM_METHOD, ATM_USER_WITH_PERMISSIONS_MODEL_METHOD. Setting only one or two will raise ``ImproperlyConfigured``
 
 


### PR DESCRIPTION
Changes include:

- standardize methods in examples
- standardize all references to the project to be `Django automations` (plural). If you prefer some other way, please let me know.
- spelling
- add notes
- correct name references to methods
